### PR TITLE
Fix multiline issues hash calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed multiline issues hash calculation. ([@skryukov])
+
 ## [0.1.0] - 2022-07-03
 
 ### Added

--- a/lib/rubocop/gradual/results/file.rb
+++ b/lib/rubocop/gradual/results/file.rb
@@ -35,8 +35,18 @@ module RuboCop
         def issue_hash(issue)
           return issue[:hash] if issue[:hash]
 
-          code = data.lines[issue[:line] - 1..].join("\n")[issue[:column] - 1, issue[:length]]
-          djb2a(code)
+          djb2a(fetch_code(issue[:line] - 1, issue[:column] - 1, issue[:length]))
+        end
+
+        def fetch_code(line, column, length)
+          code = ""
+          data.each_line.lazy.drop(line).each_with_index do |str, index|
+            from = index.zero? ? column : 0
+            length = index.zero? ? length : length - code.length
+            code += str[from, length]
+
+            return code if code.length >= length
+          end
         end
 
         def data

--- a/spec/fixtures/project/full.lock
+++ b/spec/fixtures/project/full.lock
@@ -6,17 +6,17 @@
     [1, 1, 1, "Style/FrozenStringLiteralComment: Missing frozen string literal comment.", 177606],
     [1, 1, 21, "Style/Documentation: Missing top-level documentation comment for `class BooksController`.", 2020578605],
     [2, 34, 33, "Style/SymbolArray: Use `%i` or `%I` for an array of symbols.", 4040535139],
-    [8, 3, 14, "Style/EmptyMethod: Put empty method definitions on a single line.", 1786506282],
-    [15, 3, 14, "Style/EmptyMethod: Put empty method definitions on a single line.", 1812028981],
+    [8, 3, 14, "Style/EmptyMethod: Put empty method definitions on a single line.", 1838757028],
+    [15, 3, 14, "Style/EmptyMethod: Put empty method definitions on a single line.", 1835812475],
     [23, 121, 1, "Layout/LineLength: Line is too long. [121/120]", 177604],
     [37, 121, 1, "Layout/LineLength: Line is too long. [121/120]", 177604],
     [51, 121, 1, "Layout/LineLength: Line is too long. [121/120]", 177604],
     [56, 3, 7, "Layout/EmptyLinesAroundAccessModifier: Keep a blank line before and after `private`.", 1807578568],
     [58, 1, 4, "Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.", 2085287685],
-    [58, 5, 57, "Layout/IndentationConsistency: Inconsistent indentation detected.", 1215737705],
+    [58, 5, 57, "Layout/IndentationConsistency: Inconsistent indentation detected.", 1468944780],
     [62, 121, 1, "Layout/LineLength: Line is too long. [121/120]", 177604],
     [63, 1, 4, "Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.", 2085287685],
-    [63, 5, 65, "Layout/IndentationConsistency: Inconsistent indentation detected.", 1739255269]
+    [63, 5, 65, "Layout/IndentationConsistency: Inconsistent indentation detected.", 1981439488]
   ],
   "app/models/book.rb:1943755482": [
     [1, 1, 1, "Style/FrozenStringLiteralComment: Missing frozen string literal comment.", 177606],

--- a/spec/fixtures/project/outdated.lock
+++ b/spec/fixtures/project/outdated.lock
@@ -6,17 +6,17 @@
     [1, 1, 1, "Style/FrozenStringLiteralComment: Missing frozen string literal comment.", 177606],
     [1, 1, 21, "Style/Documentation: Missing top-level documentation comment for `class BooksController`.", 2020578605],
     [2, 34, 33, "Style/SymbolArray: Use `%i` or `%I` for an array of symbols.", 4040535139],
-    [12, 3, 14, "Style/EmptyMethod: Put empty method definitions on a single line.", 1786506282],
-    [21, 3, 14, "Style/EmptyMethod: Put empty method definitions on a single line.", 1812028981],
+    [12, 3, 14, "Style/EmptyMethod: Put empty method definitions on a single line.", 1838757028],
+    [21, 3, 14, "Style/EmptyMethod: Put empty method definitions on a single line.", 1835812475],
     [31, 121, 1, "Layout/LineLength: Line is too long. [121/120]", 177604],
     [45, 121, 1, "Layout/LineLength: Line is too long. [121/120]", 177604],
     [59, 121, 1, "Layout/LineLength: Line is too long. [121/120]", 177604],
     [64, 3, 7, "Layout/EmptyLinesAroundAccessModifier: Keep a blank line before and after `private`.", 1807578568],
     [66, 1, 4, "Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.", 2085287685],
-    [66, 5, 57, "Layout/IndentationConsistency: Inconsistent indentation detected.", 1215737705],
+    [66, 5, 57, "Layout/IndentationConsistency: Inconsistent indentation detected.", 1468944780],
     [70, 121, 1, "Layout/LineLength: Line is too long. [121/120]", 177604],
     [71, 1, 4, "Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.", 2085287685],
-    [71, 5, 65, "Layout/IndentationConsistency: Inconsistent indentation detected.", 1739255269]
+    [71, 5, 65, "Layout/IndentationConsistency: Inconsistent indentation detected.", 1981439488]
   ],
   "app/models/book.rb:1943755482": [
     [1, 1, 1, "Style/FrozenStringLiteralComment: Missing frozen string literal comment.", 177606],

--- a/spec/fixtures/project/was_better.lock
+++ b/spec/fixtures/project/was_better.lock
@@ -5,17 +5,17 @@
   "app/controllers/books_controller.rb:2782135345": [
     [2, 1, 1, "Layout/EmptyLinesAroundClassBody: Extra empty line detected at class body beginning.", 177583],
     [3, 34, 33, "Style/SymbolArray: Use `%i` or `%I` for an array of symbols.", 4040535139],
-    [13, 3, 14, "Style/EmptyMethod: Put empty method definitions on a single line.", 1786506282],
-    [22, 3, 14, "Style/EmptyMethod: Put empty method definitions on a single line.", 1812028981],
+    [13, 3, 14, "Style/EmptyMethod: Put empty method definitions on a single line.", 1838757028],
+    [22, 3, 14, "Style/EmptyMethod: Put empty method definitions on a single line.", 1835812475],
     [32, 121, 1, "Layout/LineLength: Line is too long. [121/120]", 177604],
     [46, 121, 1, "Layout/LineLength: Line is too long. [121/120]", 177604],
     [60, 121, 1, "Layout/LineLength: Line is too long. [121/120]", 177604],
     [65, 3, 7, "Layout/EmptyLinesAroundAccessModifier: Keep a blank line before and after `private`.", 1807578568],
     [67, 1, 4, "Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.", 2085287685],
-    [67, 5, 57, "Layout/IndentationConsistency: Inconsistent indentation detected.", 1215737705],
+    [67, 5, 57, "Layout/IndentationConsistency: Inconsistent indentation detected.", 1468944780],
     [71, 121, 1, "Layout/LineLength: Line is too long. [121/120]", 177604],
     [72, 1, 4, "Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.", 2085287685],
-    [72, 5, 65, "Layout/IndentationConsistency: Inconsistent indentation detected.", 1739255269]
+    [72, 5, 65, "Layout/IndentationConsistency: Inconsistent indentation detected.", 1981439488]
   ],
   "app/models/book.rb:1943755482": [
     [1, 1, 1, "Style/FrozenStringLiteralComment: Missing frozen string literal comment.", 177606],

--- a/spec/fixtures/project/was_worse.lock
+++ b/spec/fixtures/project/was_worse.lock
@@ -6,17 +6,17 @@
     [1, 1, 1, "Style/FrozenStringLiteralComment: Missing frozen string literal comment.", 177606],
     [1, 1, 21, "Style/Documentation: Missing top-level documentation comment for `class BooksController`.", 2020578605],
     [2, 34, 33, "Style/SymbolArray: Use `%i` or `%I` for an array of symbols.", 4040535139],
-    [8, 3, 14, "Style/EmptyMethod: Put empty method definitions on a single line.", 1786506282],
-    [15, 3, 14, "Style/EmptyMethod: Put empty method definitions on a single line.", 1812028981],
+    [8, 3, 14, "Style/EmptyMethod: Put empty method definitions on a single line.", 1838757028],
+    [15, 3, 14, "Style/EmptyMethod: Put empty method definitions on a single line.", 1835812475],
     [23, 121, 1, "Layout/LineLength: Line is too long. [121/120]", 177604],
     [37, 121, 1, "Layout/LineLength: Line is too long. [121/120]", 177604],
     [51, 121, 1, "Layout/LineLength: Line is too long. [121/120]", 177604],
     [56, 3, 7, "Layout/EmptyLinesAroundAccessModifier: Keep a blank line before and after `private`.", 1807578568],
     [58, 1, 4, "Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.", 2085287685],
-    [58, 5, 57, "Layout/IndentationConsistency: Inconsistent indentation detected.", 1215737705],
+    [58, 5, 57, "Layout/IndentationConsistency: Inconsistent indentation detected.", 1468944780],
     [62, 121, 1, "Layout/LineLength: Line is too long. [121/120]", 177604],
     [63, 1, 4, "Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.", 2085287685],
-    [63, 5, 65, "Layout/IndentationConsistency: Inconsistent indentation detected.", 1739255269]
+    [63, 5, 65, "Layout/IndentationConsistency: Inconsistent indentation detected.", 1981439488]
   ],
   "app/models/book.rb:3090658385": [
     [1, 1, 1, "Style/FrozenStringLiteralComment: Missing frozen string literal comment.", 177606],


### PR DESCRIPTION
There was an issue with hash calculation for multiline code snippets due to `.join("\n")` call.

This PR resolves that issue and also refactors code-extracting logic to a bit more memory efficient.
