### PR TITLE
Add built-in Rake tasks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,3 +34,6 @@ RSpec/ExpectOutput:
 
 RSpec/MultipleExpectations:
     Enabled: false
+
+RSpec/NestedGroups:
+  Max: 4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+### Added
+
+- Built-in Rake tasks. ([@skryukov])
+```ruby
+# Rakefile
+require "rubocop/gradual/rake_task"
+
+RuboCop::Gradual::RakeTask.new
+```
+
 ## [0.2.0] - 2022-07-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -54,6 +54,41 @@ Proposed workflow:
     -h, --help                       Prints this help.
 ```
 
+## Rake tasks
+
+To use built-in Rake tasks add the following to your Rakefile:
+
+```ruby
+# Rakefile
+require "rubocop/gradual/rake_task"
+
+RuboCop::Gradual::RakeTask.new
+```
+
+This will add rake tasks:
+
+```
+bundle exec rake -T
+rake rubocop_gradual                  # Run RuboCop Gradual
+rake rubocop_gradual:autocorrect      # Run RuboCop Gradual with autocorrect (only when it's safe)
+rake rubocop_gradual:autocorrect_all  # Run RuboCop Gradual with autocorrect (safe and unsafe)
+rake rubocop_gradual:check            # Run RuboCop Gradual to check the lock file
+rake rubocop_gradual:force_update     # Run RuboCop Gradual to force update the lock file
+```
+
+It's possible to customize the Rake task name and options:
+
+```ruby
+# Rakefile
+
+require "rubocop/gradual/rake_task"
+
+RuboCop::Gradual::RakeTask.new(:custom_task_name) do |task|
+  task.options = %w[--gradual-file custom_gradual_file.lock]
+  task.verbose = false
+end
+```
+
 ## Alternatives
 
 - [RuboCop TODO file]. Comes out of the box with RuboCop. Provides a way to ignore offenses on the file level, which is problematic since it is possible to introduce new offenses without any signal from linter.

--- a/lib/rubocop/gradual/rake_task.rb
+++ b/lib/rubocop/gradual/rake_task.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "rake"
+require "rake/tasklib"
+
+module RuboCop
+  module Gradual
+    # Rake tasks for RuboCop::Gradual.
+    #
+    # @example
+    #   require "rubocop/gradual/rake_task"
+    #   RuboCop::Gradual::RakeTask.new
+    #
+    class RakeTask < ::Rake::TaskLib
+      attr_accessor :name, :verbose, :options
+
+      def initialize(name = :rubocop_gradual, *args, &task_block)
+        super()
+        @name = name
+        @verbose = true
+        @options = []
+        define(args, &task_block)
+      end
+
+      private
+
+      def define(args, &task_block)
+        desc "Run RuboCop Gradual" unless ::Rake.application.last_description
+        define_task(name, nil, args, &task_block)
+        setup_subtasks(args, &task_block)
+      end
+
+      def setup_subtasks(args, &task_block)
+        namespace(name) do
+          desc "Run RuboCop Gradual with autocorrect (only when it's safe)."
+          define_task(:autocorrect, "--autocorrect", args, &task_block)
+
+          desc "Run RuboCop Gradual with autocorrect (safe and unsafe)."
+          define_task(:autocorrect_all, "--autocorrect-all", args, &task_block)
+
+          desc "Run RuboCop Gradual to check the lock file."
+          define_task(:check, "--check", args, &task_block)
+
+          desc "Run RuboCop Gradual to force update the lock file."
+          define_task(:force_update, "--force-update", args, &task_block)
+        end
+      end
+
+      def define_task(name, option, args, &task_block)
+        task(name, *args) do |_, task_args|
+          RakeFileUtils.verbose(verbose) do
+            yield(*[self, task_args].slice(0, task_block.arity)) if task_block
+            run_cli(verbose, option)
+          end
+        end
+      end
+
+      def run_cli(verbose, option)
+        require "rubocop-gradual"
+
+        cli = CLI.new
+        puts "Running RuboCop Gradual..." if verbose
+        result = cli.run(full_options(option))
+        abort("RuboCop Gradual failed!") if result.nonzero?
+      end
+
+      def full_options(option)
+        option ? options.flatten.unshift(option) : options.flatten
+      end
+    end
+  end
+end

--- a/spec/rubocop/gradual/rake_task_spec.rb
+++ b/spec/rubocop/gradual/rake_task_spec.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+require "rubocop/gradual/rake_task"
+
+RSpec.describe RuboCop::Gradual::RakeTask do
+  before { Rake::Task.clear }
+
+  after { Rake::Task.clear }
+
+  describe "defining tasks" do
+    it "creates a rubocop_gradual task and a rubocop_gradual autocorrect task" do
+      described_class.new
+
+      expect(Rake::Task.task_defined?(:rubocop_gradual)).to be true
+      expect(Rake::Task.task_defined?("rubocop_gradual:autocorrect")).to be true
+    end
+
+    it "creates a named task and a named autocorrect task" do
+      described_class.new(:lint_lib)
+
+      expect(Rake::Task.task_defined?(:lint_lib)).to be true
+      expect(Rake::Task.task_defined?("lint_lib:autocorrect")).to be true
+    end
+
+    it "creates a rubocop task and a rubocop autocorrect_all task" do
+      described_class.new
+
+      expect(Rake::Task.task_defined?(:rubocop_gradual)).to be true
+      expect(Rake::Task.task_defined?("rubocop_gradual:autocorrect_all")).to be true
+    end
+
+    it "creates a named task and a named autocorrect_all task" do
+      described_class.new(:lint_lib)
+
+      expect(Rake::Task.task_defined?(:lint_lib)).to be true
+      expect(Rake::Task.task_defined?("lint_lib:autocorrect_all")).to be true
+    end
+  end
+
+  describe "running tasks" do
+    before do
+      $stdout = StringIO.new
+      $stderr = StringIO.new
+    end
+
+    after do
+      $stdout = STDOUT
+      $stderr = STDERR
+    end
+
+    let!(:cli) do
+      instance_double(RuboCop::Gradual::CLI, run: cli_result).tap do |cli|
+        allow(RuboCop::Gradual::CLI).to receive(:new).and_return(cli)
+      end
+    end
+    let(:cli_result) { 0 }
+
+    it "runs with default options" do
+      described_class.new
+
+      Rake::Task["rubocop_gradual"].execute
+
+      expect(cli).to have_received(:run).with([])
+    end
+
+    context "with specified options" do
+      let(:rake_task) do
+        described_class.new do |task|
+          task.options = ["--display-time"]
+          task.verbose = false
+        end
+      end
+
+      it "runs with specified options" do
+        rake_task
+        Rake::Task["rubocop_gradual"].execute
+
+        expect(cli).to have_received(:run).with(%w[--display-time])
+      end
+    end
+
+    it "allows nested arrays inside options" do
+      described_class.new do |task|
+        task.options = [%w[--gradual-file custom_gradual_file.lock]]
+      end
+
+      Rake::Task["rubocop_gradual"].execute
+
+      expect(cli).to have_received(:run).with(%w[--gradual-file custom_gradual_file.lock])
+    end
+
+    context "when cli returns non-zero" do
+      let(:cli_result) { 1 }
+
+      it "raises error" do
+        described_class.new
+        expect { Rake::Task["rubocop_gradual"].execute }.to raise_error(SystemExit)
+      end
+    end
+
+    describe "autocorrect" do
+      it "runs with --autocorrect" do
+        described_class.new
+        Rake::Task["rubocop_gradual:autocorrect"].execute
+
+        expect(cli).to have_received(:run).with(["--autocorrect"])
+      end
+
+      it "runs with --autocorrect-all" do
+        described_class.new
+        Rake::Task["rubocop_gradual:autocorrect_all"].execute
+
+        expect(cli).to have_received(:run).with(["--autocorrect-all"])
+      end
+
+      context "with specified options" do
+        let(:rake_task) do
+          described_class.new do |task|
+            task.options = ["--debug"]
+            task.verbose = false
+          end
+        end
+
+        it "runs with specified options" do
+          rake_task
+          Rake::Task["rubocop_gradual:autocorrect_all"].execute
+
+          expect(cli).to have_received(:run).with(%w[--autocorrect-all --debug])
+        end
+      end
+    end
+
+    describe "check" do
+      it "runs with --check" do
+        described_class.new
+
+        Rake::Task["rubocop_gradual:check"].execute
+
+        expect(cli).to have_received(:run).with(["--check"])
+      end
+    end
+
+    describe "force_update" do
+      it "runs with --force-update" do
+        described_class.new
+
+        Rake::Task["rubocop_gradual:force_update"].execute
+
+        expect(cli).to have_received(:run).with(["--force-update"])
+      end
+    end
+  end
+end


### PR DESCRIPTION

To use built-in Rake tasks add the following to your Rakefile:

```ruby
# Rakefile
require "rubocop/gradual/rake_task"

RuboCop::Gradual::RakeTask.new
```

This will add rake tasks:

```
bundle exec rake -T
rake rubocop_gradual                  # Run RuboCop Gradual
rake rubocop_gradual:autocorrect      # Run RuboCop Gradual with autocorrect (only when it's safe)
rake rubocop_gradual:autocorrect_all  # Run RuboCop Gradual with autocorrect (safe and unsafe)
rake rubocop_gradual:check            # Run RuboCop Gradual to check the lock file
```

It's possible to customize the Rake task name and options:

```ruby
# Rakefile

require "rubocop/gradual/rake_task"

RuboCop::Gradual::RakeTask.new(:custom_task_name) do |task|
  task.options = %w[--gradual-file custom_gradual_file.lock]
  task.verbose = false
end
```