### PR TITLE
Add experimental "Require mode"

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,7 @@ AllCops:
   Exclude:
     - 'spec/fixtures/**/*'
     - 'vendor/**/*'
+
 Style/StringLiterals:
   Enabled: true
   EnforcedStyle: double_quotes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning].
 
 ### Added
 
+- Require mode (experimental). ([@skryukov])
+
 - Built-in Rake tasks. ([@skryukov])
 ```ruby
 # Rakefile

--- a/README.md
+++ b/README.md
@@ -89,6 +89,40 @@ RuboCop::Gradual::RakeTask.new(:custom_task_name) do |task|
 end
 ```
 
+## Require mode (experimental)
+
+RuboCop Gradual can be used in "Require mode", which is a way to replace `rubocop` with `rubocop-gradual`:
+
+```yaml
+# .rubocop.yml
+
+require:
+  - rubocop-gradual
+```
+
+Now base `rubocop` command will run `rubocop-gradual`:
+
+```shell
+rubocop # run `rubocop-gradual`
+rubocop -a # run `rubocop-gradual` with autocorrect (only when it's safe)
+rubocop -A # run `rubocop-gradual` with autocorrect (safe and unsafe)
+rubocop gradual check # run `rubocop-gradual` to check the lock file
+rubocop gradual force_update # run `rubocop-gradual` to force update the lock file
+```
+
+To set a custom path to Gradual lock file, add `--gradual-file FILE` to a special `.rubocop-gradual` file:
+
+```
+# .rubocop-gradual
+--rubocop-gradual-file path/to/my_lock_file.lock
+```
+
+To temporarily disable RuboCop Gradual, prepend command with `NO_GRADUAL=1`:
+
+```shell
+NO_GRADUAL=1 rubocop # run `rubocop`
+```
+
 ## Alternatives
 
 - [RuboCop TODO file]. Comes out of the box with RuboCop. Provides a way to ignore offenses on the file level, which is problematic since it is possible to introduce new offenses without any signal from linter.

--- a/lib/rubocop/gradual.rb
+++ b/lib/rubocop/gradual.rb
@@ -11,3 +11,8 @@ module RuboCop
     class Error < StandardError; end
   end
 end
+
+if ENV["NO_GRADUAL"] != "1" && (RuboCop::ConfigLoader.loaded_features & %w[rubocop-gradual rubocop/gradual]).any?
+  require_relative "gradual/patch"
+  RuboCop::CLI.prepend(RuboCop::Gradual::Patch)
+end

--- a/lib/rubocop/gradual/patch.rb
+++ b/lib/rubocop/gradual/patch.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rubocop-gradual"
+
+module RuboCop
+  module Gradual
+    # Patching RuboCop::CLI to enable require mode.
+    module Patch
+      def run_command(name)
+        return super if name != :execute_runner || (ARGV & %w[--stdin -s]).any?
+
+        Configuration.apply(*parse_options)
+        puts "Gradual mode: #{Configuration.mode}" if Configuration.debug?
+        load_command(Configuration.command).call.to_i
+      end
+
+      private
+
+      def load_command(command)
+        require_relative "commands/#{command}"
+        ::RuboCop::Gradual::Commands.const_get(command.to_s.capitalize).new
+      end
+
+      def parse_options
+        options, rubocop_options = Options.new.parse(ARGV)
+        options[:mode] = :force_update if @env.paths[0..1] == %w[gradual force_update]
+        options[:mode] = :check if @env.paths[0..1] == %w[gradual check]
+        [options, rubocop_options]
+      end
+    end
+  end
+end


### PR DESCRIPTION
RuboCop Gradual can be used in "Require mode", which is a way to replace `rubocop` with `rubocop-gradual`:

```yaml
# .rubocop.yml
require:
  - rubocop-gradual
```

Now base `rubocop` command will run `rubocop-gradual`:

```shell
rubocop # run `rubocop-gradual`
rubocop -a # run `rubocop-gradual` with autocorrect (only when it's safe)
rubocop -A # run `rubocop-gradual` with autocorrect (safe and unsafe)
rubocop gradual check # run `rubocop-gradual` to check the lock file
rubocop gradual force_update # run `rubocop-gradual` to force update the lock file
```