### PR TITLE
Support partial linting (experimental)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning].
 
 ### Added
 
+- Partial linting (experimental). ([@skryukov])
+  Partial linting is useful when you want to run RuboCop Gradual on a subset of files, for example, on changed files in a pull request:
+```shell
+rubocop-gradual path/to/file # run `rubocop-gradual` on a subset of files
+rubocop-gradual --staged # run `rubocop-gradual` on staged files
+rubocop-gradual --unstaged # run `rubocop-gradual` on unstaged files
+rubocop-gradual --commit origin/main # run `rubocop-gradual` on changed files since the commit
+
+# it's possible to combine options with autocorrect:
+rubocop-gradual --staged --autocorrect # run `rubocop-gradual` with autocorrect on staged files
+```
+
 - Require mode (experimental). ([@skryukov])
 
 - Built-in Rake tasks. ([@skryukov])

--- a/README.md
+++ b/README.md
@@ -89,6 +89,22 @@ RuboCop::Gradual::RakeTask.new(:custom_task_name) do |task|
 end
 ```
 
+## Partial linting (experimental)
+
+RuboCop Gradual supports partial linting. It's useful when you want to run RuboCop Gradual on a subset of files, for example, on changed files in a pull request:
+
+```shell
+rubocop-gradual path/to/file # run `rubocop-gradual` on a subset of files
+rubocop-gradual --staged # run `rubocop-gradual` on staged files
+rubocop-gradual --unstaged # run `rubocop-gradual` on unstaged files
+rubocop-gradual --commit origin/main # run `rubocop-gradual` on changed files since the commit
+
+# it's possible to combine options with autocorrect:
+rubocop-gradual --staged --autocorrect # run `rubocop-gradual` with autocorrect on staged files
+```
+
+To run
+
 ## Require mode (experimental)
 
 RuboCop Gradual can be used in "Require mode", which is a way to replace `rubocop` with `rubocop-gradual`:

--- a/lib/rubocop/gradual/commands/base.rb
+++ b/lib/rubocop/gradual/commands/base.rb
@@ -27,10 +27,16 @@ module RuboCop
             RuboCop::CLI::Environment.new(
               rubocop_options,
               Configuration.rubocop_config_store,
-              []
+              lint_paths
             )
           )
           rubocop_runner.run
+        end
+
+        def lint_paths
+          return [] if Configuration.lint_paths.empty?
+
+          Configuration.target_file_paths
         end
 
         def rubocop_options

--- a/lib/rubocop/gradual/configuration.rb
+++ b/lib/rubocop/gradual/configuration.rb
@@ -5,11 +5,13 @@ module RuboCop
     # Configuration class stores Gradual and Rubocop options.
     module Configuration
       class << self
-        attr_reader :options, :rubocop_options, :rubocop_results
+        attr_reader :options, :rubocop_options, :rubocop_results, :lint_paths, :target_file_paths
 
-        def apply(options = {}, rubocop_options = {})
+        def apply(options = {}, rubocop_options = {}, lint_paths = [])
           @options = options
           @rubocop_options = rubocop_options
+          @lint_paths = lint_paths
+          @target_file_paths = rubocop_target_file_paths
           @rubocop_results = []
         end
 
@@ -37,6 +39,20 @@ module RuboCop
           RuboCop::ConfigStore.new.tap do |config_store|
             config_store.options_config = rubocop_options[:config] if rubocop_options[:config]
           end
+        end
+
+        private
+
+        def rubocop_target_file_paths
+          target_finder = RuboCop::TargetFinder.new(rubocop_config_store, rubocop_options)
+          mode = if rubocop_options[:only_recognized_file_types]
+                   :only_recognized_file_types
+                 else
+                   :all_file_types
+                 end
+          target_finder
+            .find(lint_paths, mode)
+            .map { |path| RuboCop::PathUtil.smart_path(path) }
         end
       end
     end

--- a/lib/rubocop/gradual/git.rb
+++ b/lib/rubocop/gradual/git.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rbconfig"
+
+module RuboCop
+  module Gradual
+    # Git class handles git commands.
+    module Git
+      class << self
+        def paths_by(commit)
+          git_installed!
+
+          case commit
+          when :unstaged
+            `git ls-files --others --exclude-standard -m`.split("\n")
+          when :staged
+            `git diff --cached --name-only`.split("\n")
+          else
+            `git diff --name-only #{commit}`.split("\n")
+          end
+        end
+
+        private
+
+        def git_installed!
+          void = /msdos|mswin|djgpp|mingw/.match?(RbConfig::CONFIG["host_os"]) ? "NUL" : "/dev/null"
+          git_found = `git --version >>#{void} 2>&1`
+
+          raise Error, "Git is not found, please install it first." unless git_found
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/gradual/process/calculate_diff.rb
+++ b/lib/rubocop/gradual/process/calculate_diff.rb
@@ -10,7 +10,7 @@ module RuboCop
       module CalculateDiff
         class << self
           def call(new_result, old_result)
-            return Diff.new.add_new(new_result.files) if old_result.nil?
+            return Diff.new.add_files(new_result.files, :new) if old_result.nil?
 
             diff_results(new_result, old_result)
           end
@@ -20,7 +20,7 @@ module RuboCop
           def diff_results(new_result, old_result)
             new_files, fixed_files, path_files_match, moved_files_match = split_files(new_result, old_result)
 
-            diff = Diff.new.add_new(new_files).add_fixed(fixed_files)
+            diff = Diff.new.add_files(new_files, :new).add_files(fixed_files, :fixed)
             path_files_match.chain(moved_files_match).each do |result_file, old_file|
               diff_issues(diff, result_file, old_file)
             end
@@ -72,19 +72,6 @@ module RuboCop
               possible_issue.code_hash == issue.code_hash
             end
             possibilities.min_by { |possibility| issue.distance(possibility) }
-          end
-
-          def map_same_files(left, right)
-            map_files(left.files, right.files) do |new_file, old_file|
-              new_file.path == old_file.path
-            end
-          end
-
-          def map_files(key_files, value_files)
-            key_files.each_with_object({}) do |key_file, res|
-              same_file = value_files.find { |value_file| yield(key_file, value_file) }
-              res[key_file] = same_file if same_file
-            end
           end
         end
       end

--- a/lib/rubocop/gradual/process/diff.rb
+++ b/lib/rubocop/gradual/process/diff.rb
@@ -33,16 +33,9 @@ module RuboCop
             end
         end
 
-        def add_new(files)
+        def add_files(files, key)
           files.each do |file|
-            add_issues(file.path, new: file.issues)
-          end
-          self
-        end
-
-        def add_fixed(files)
-          files.each do |file|
-            add_issues(file.path, fixed: file.issues)
+            add_issues(file.path, **{ key => file.issues })
           end
           self
         end


### PR DESCRIPTION
Partial linting might be useful to run RuboCop Gradual on a subset of files, for example, on changed files in a pull request:

```shell
rubocop-gradual path/to/file # run `rubocop-gradual` on a subset of files
rubocop-gradual --staged # run `rubocop-gradual` on staged files
rubocop-gradual --unstaged # run `rubocop-gradual` on unstaged files
rubocop-gradual --commit origin/main # run `rubocop-gradual` on changed files since the commit

# it's possible to combine options with autocorrect:
rubocop-gradual --staged --autocorrect # run `rubocop-gradual` with autocorrect on staged files
```