### PR TITLE
Handle syntax errors

### DIFF
--- a/lib/rubocop/gradual/results/file.rb
+++ b/lib/rubocop/gradual/results/file.rb
@@ -45,8 +45,9 @@ module RuboCop
             length = index.zero? ? length : length - code.length
             code += str[from, length]
 
-            return code if code.length >= length
+            break if code.length >= length
           end
+          code
         end
 
         def data

--- a/spec/fixtures/project/autocorrected.lock
+++ b/spec/fixtures/project/autocorrected.lock
@@ -1,6 +1,7 @@
 {
   "app/controllers/application_controller.rb:1968181156": [
-    [1, 1, 1, "Style/FrozenStringLiteralComment: Missing frozen string literal comment.", 177606]
+    [1, 1, 1, "Style/FrozenStringLiteralComment: Missing frozen string literal comment.", 177606],
+    [1, 1, 27, "Style/Documentation: Missing top-level documentation comment for `class ApplicationController`.", 162509677]
   ],
   "app/controllers/books_controller.rb:4260410131": [
     [1, 1, 1, "Style/FrozenStringLiteralComment: Missing frozen string literal comment.", 177606],

--- a/spec/fixtures/project/full.lock
+++ b/spec/fixtures/project/full.lock
@@ -1,6 +1,7 @@
 {
   "app/controllers/application_controller.rb:1968181156": [
-    [1, 1, 1, "Style/FrozenStringLiteralComment: Missing frozen string literal comment.", 177606]
+    [1, 1, 1, "Style/FrozenStringLiteralComment: Missing frozen string literal comment.", 177606],
+    [1, 1, 27, "Style/Documentation: Missing top-level documentation comment for `class ApplicationController`.", 162509677]
   ],
   "app/controllers/books_controller.rb:1335398035": [
     [1, 1, 1, "Style/FrozenStringLiteralComment: Missing frozen string literal comment.", 177606],

--- a/spec/fixtures/project/outdated.lock
+++ b/spec/fixtures/project/outdated.lock
@@ -1,6 +1,7 @@
 {
   "app/controllers/application_controller.rb:1968181156": [
-    [1, 1, 1, "Style/FrozenStringLiteralComment: Missing frozen string literal comment.", 177606]
+    [1, 1, 1, "Style/FrozenStringLiteralComment: Missing frozen string literal comment.", 177606],
+    [1, 1, 27, "Style/Documentation: Missing top-level documentation comment for `class ApplicationController`.", 162509677]
   ],
   "app/controllers/books_controller.rb:3244390747": [
     [1, 1, 1, "Style/FrozenStringLiteralComment: Missing frozen string literal comment.", 177606],

--- a/spec/fixtures/project/was_better.lock
+++ b/spec/fixtures/project/was_better.lock
@@ -1,6 +1,7 @@
 {
   "app/controllers/application_controller.rb:1968181156": [
-    [1, 1, 1, "Style/FrozenStringLiteralComment: Missing frozen string literal comment.", 177606]
+    [1, 1, 1, "Style/FrozenStringLiteralComment: Missing frozen string literal comment.", 177606],
+    [1, 1, 27, "Style/Documentation: Missing top-level documentation comment for `class ApplicationController`.", 162509677]
   ],
   "app/controllers/books_controller.rb:2782135345": [
     [2, 1, 1, "Layout/EmptyLinesAroundClassBody: Extra empty line detected at class body beginning.", 177583],

--- a/spec/fixtures/project/was_worse.lock
+++ b/spec/fixtures/project/was_worse.lock
@@ -1,6 +1,7 @@
 {
   "app/controllers/application_controller.rb:1968181156": [
-    [1, 1, 1, "Style/FrozenStringLiteralComment: Missing frozen string literal comment.", 177606]
+    [1, 1, 1, "Style/FrozenStringLiteralComment: Missing frozen string literal comment.", 177606],
+    [1, 1, 27, "Style/Documentation: Missing top-level documentation comment for `class ApplicationController`.", 162509677]
   ],
   "app/controllers/books_controller.rb:1335398035": [
     [1, 1, 1, "Style/FrozenStringLiteralComment: Missing frozen string literal comment.", 177606],

--- a/spec/rubocop/gradual_spec.rb
+++ b/spec/rubocop/gradual_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe RuboCop::Gradual, :aggregate_failures do
   it "writes full file for the first time" do
     expect(gradual_cli).to eq(0)
     expect(actual_data).to eq(expected_data)
-    expect($stdout.string).to include("RuboCop Gradual got results for the first time. 22 issue(s) found.")
+    expect($stdout.string).to include("RuboCop Gradual got results for the first time. 23 issue(s) found.")
   end
 
   include_examples "error with --check option"
@@ -134,7 +134,7 @@ RSpec.describe RuboCop::Gradual, :aggregate_failures do
     it "updates file" do
       expect(gradual_cli).to eq(0)
       expect(actual_data).to eq(expected_data)
-      expect($stdout.string).to include("RuboCop Gradual got 2 issue(s) fixed, 22 left. Keep going!")
+      expect($stdout.string).to include("RuboCop Gradual got 2 issue(s) fixed, 23 left. Keep going!")
     end
 
     include_examples "error with --check option"
@@ -163,7 +163,7 @@ RSpec.describe RuboCop::Gradual, :aggregate_failures do
       expect(actual_data).to eq(expected_data)
       expect($stdout.string).to include("Inspecting 3 file(s) for autocorrection...")
         .and include("Fixed 2 file(s).")
-        .and include("RuboCop Gradual got 13 issue(s) fixed, 9 left. Keep going!")
+        .and include("RuboCop Gradual got 13 issue(s) fixed, 10 left. Keep going!")
     end
   end
 end


### PR DESCRIPTION
This PR fixes an error that happens when RuboCop encounters a syntax error, for example:

```ruby
{:line=>56, :column=>1, :length=>0, :message=>"Lint/Syntax: unexpected token $end\n(Using Ruby 3.1 parser; configure using `TargetRubyVersion` parameter, under `AllCops`)"}
```