### PR TITLE
fix: throw error when file hash is outdated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+### Fixed
+
+- Throw an error when the `--check` option is used and file hash is outdated. ([@skryukov])
+
 ## [0.3.2] - 2023-10-10
 
 ### Fixed

--- a/lib/rubocop/gradual/process/calculate_diff.rb
+++ b/lib/rubocop/gradual/process/calculate_diff.rb
@@ -41,17 +41,18 @@ module RuboCop
           end
 
           def diff_issues(diff, result_file, old_file)
-            fixed_or_moved_issues = old_file.changed_issues(result_file)
-            new_or_moved_issues = result_file.changed_issues(old_file)
-            moved_issues, fixed_issues = split_issues(fixed_or_moved_issues, new_or_moved_issues)
+            fixed_or_moved = old_file.changed_issues(result_file)
+            new_or_moved = result_file.changed_issues(old_file)
+            moved, fixed = split_issues(fixed_or_moved, new_or_moved)
+            new = new_or_moved - moved
+            unchanged = result_file.issues - new - moved
 
-            diff.add_issues(
-              result_file.path,
-              fixed: fixed_issues,
-              moved: moved_issues,
-              new: new_or_moved_issues - moved_issues,
-              unchanged: result_file.issues - new_or_moved_issues - moved_issues
-            )
+            if result_file.file_hash != old_file.file_hash && fixed.empty? && new.empty? && moved.empty?
+              moved = unchanged
+              unchanged = []
+            end
+
+            diff.add_issues(result_file.path, fixed: fixed, moved: moved, new: new, unchanged: unchanged)
           end
 
           def split_issues(fixed_or_moved_issues, new_or_moved_issues)

--- a/spec/fixtures/project/outdated_file.lock
+++ b/spec/fixtures/project/outdated_file.lock
@@ -1,0 +1,30 @@
+{
+  "app/controllers/application_controller.rb:4242424242": [
+    [1, 1, 1, "Style/FrozenStringLiteralComment: Missing frozen string literal comment.", 177606],
+    [1, 1, 27, "Style/Documentation: Missing top-level documentation comment for `class ApplicationController`.", 162509677]
+  ],
+  "app/controllers/books_controller.rb:1335398035": [
+    [1, 1, 1, "Style/FrozenStringLiteralComment: Missing frozen string literal comment.", 177606],
+    [1, 1, 21, "Style/Documentation: Missing top-level documentation comment for `class BooksController`.", 2020578605],
+    [2, 34, 33, "Style/SymbolArray: Use `%i` or `%I` for an array of symbols.", 4040535139],
+    [8, 3, 14, "Style/EmptyMethod: Put empty method definitions on a single line.", 1838757028],
+    [15, 3, 14, "Style/EmptyMethod: Put empty method definitions on a single line.", 1835812475],
+    [23, 121, 1, "Layout/LineLength: Line is too long. [121/120]", 177604],
+    [37, 121, 1, "Layout/LineLength: Line is too long. [121/120]", 177604],
+    [51, 121, 1, "Layout/LineLength: Line is too long. [121/120]", 177604],
+    [56, 3, 7, "Layout/EmptyLinesAroundAccessModifier: Keep a blank line before and after `private`.", 1807578568],
+    [58, 1, 4, "Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.", 2085287685],
+    [58, 5, 57, "Layout/IndentationConsistency: Inconsistent indentation detected.", 1468944780],
+    [62, 121, 1, "Layout/LineLength: Line is too long. [121/120]", 177604],
+    [63, 1, 4, "Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.", 2085287685],
+    [63, 5, 65, "Layout/IndentationConsistency: Inconsistent indentation detected.", 1981439488]
+  ],
+  "app/models/book.rb:1190628470": [
+    [1, 1, 1, "Style/FrozenStringLiteralComment: Missing frozen string literal comment.", 177606],
+    [1, 1, 10, "Style/Documentation: Missing top-level documentation comment for `class Book`.", 3515554338],
+    [2, 7, 10, "Naming/MethodName: Use snake_case for method names.", 3866179310],
+    [3, 5, 3, "Lint/UselessAssignment: Useless assignment to variable - `foo`.", 193410979],
+    [4, 5, 76, "Style/RescueModifier: Avoid using `rescue` in its modifier form.", 3253570103],
+    [4, 16, 19, "Style/RegexpLiteral: Use `%r` around regular expression.", 4043289893]
+  ]
+}

--- a/spec/rubocop/gradual_spec.rb
+++ b/spec/rubocop/gradual_spec.rb
@@ -71,6 +71,19 @@ RSpec.describe RuboCop::Gradual, :aggregate_failures do
     include_examples "error with --check option"
   end
 
+  context "when the lock file is outdated but only by file hash" do
+    let(:actual_lock_path) { File.expand_path("outdated_file.lock") }
+    let(:expected_lock_path) { File.expand_path("full.lock") }
+
+    it "updates file" do
+      expect(gradual_cli).to eq(0)
+      expect(actual_data).to eq(expected_data)
+      expect($stdout.string).to include("RuboCop Gradual got its results updated.")
+    end
+
+    include_examples "error with --check option"
+  end
+
   context "when the lock file is the same" do
     let(:actual_lock_path) { expected_lock_path }
 


### PR DESCRIPTION
This PR fixes the `--check` mode to throw error when file hash is outdated.