### PR TITLE
fix: wrap RuboCop errors to make output more pleasant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning].
 ### Fixed
 
 - Throw an error when the `--check` option is used and file hash is outdated. ([@skryukov])
+- Wrap RuboCop errors to make output more pleasant. ([@skryukov])
 
 ## [0.3.2] - 2023-10-10
 

--- a/lib/rubocop/gradual/commands/base.rb
+++ b/lib/rubocop/gradual/commands/base.rb
@@ -18,6 +18,9 @@ module RuboCop
           puts "Finished Gradual processing in #{time} seconds" if Configuration.display_time?
 
           exit_code
+        rescue RuboCop::Error => e
+          warn "\nRuboCop Error: #{e.message}"
+          1
         end
 
         private


### PR DESCRIPTION
This PR makes RuboCop errors look a little less cluttered:

```sh
❯ exe/rubocop-gradual non/existent/file.rb
.
RuboCop Error: No such file or directory: /Users/MatzNumberOneFan/rubocop-gradual/non/existent/file.rb
```