### PR TITLE
Use JSON.dump instead of to_json for stable encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+### Fixed
+
+- Use JSON.dump instead of to_json for stable results encoding. ([@skryukov])
+
 ## [0.3.3] - 2023-10-18
 
 ### Fixed

--- a/lib/rubocop/gradual/results/issue.rb
+++ b/lib/rubocop/gradual/results/issue.rb
@@ -20,7 +20,7 @@ module RuboCop
         end
 
         def to_s
-          "[#{[line, column, length, message.to_json, code_hash].join(", ")}]"
+          "[#{[line, column, length, JSON.dump(message), code_hash].join(", ")}]"
         end
 
         def ==(other)


### PR DESCRIPTION
ActiveSupport [uses custom encoding](https://github.com/rails/rails/blob/4c5c904a212a850c43adb7a3c3a719ca3d2b9159/activesupport/lib/active_support/json/encoding.rb#L43-L53) to escape some characters, so we want to use `JSON.dump` to get stable results.

Fixes #16