### PR TITLE
Handle files passed to rubocop in require mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+### Fixed
+
+- Respect files passed to rubocop in required mode. ([@skryukov])
+
 ## [0.3.4] - 2023-10-26
 
 ### Fixed

--- a/lib/rubocop/gradual/patch.rb
+++ b/lib/rubocop/gradual/patch.rb
@@ -22,10 +22,10 @@ module RuboCop
       end
 
       def parse_options
-        options, rubocop_options = Options.new.parse(ARGV)
+        options, *tail_options = Options.new.parse(ARGV)
         options[:mode] = :force_update if @env.paths[0..1] == %w[gradual force_update]
         options[:mode] = :check if @env.paths[0..1] == %w[gradual check]
-        [options, rubocop_options]
+        tail_options.unshift(options)
       end
     end
   end


### PR DESCRIPTION
This PR fixes #20 by passing `lint_paths` to rubocop config.