### PR TITLE
Exclude deleted files when running `--staged`

### DIFF
--- a/lib/rubocop/gradual/git.rb
+++ b/lib/rubocop/gradual/git.rb
@@ -14,7 +14,7 @@ module RuboCop
           when :unstaged
             `git ls-files --others --exclude-standard -m`.split("\n")
           when :staged
-            `git diff --cached --name-only`.split("\n")
+            `git diff --cached --name-only --diff-filter=d`.split("\n") # excludes deleted files
           else
             `git diff --name-only #{commit}`.split("\n")
           end


### PR DESCRIPTION
# What
Excludes deleted files from being included when using `--staged` argument.
- fixes: https://github.com/skryukov/rubocop-gradual/issues/26