### PR TITLE
Add `benchmark` gem to gemspec

### DIFF
--- a/rubocop-gradual.gemspec
+++ b/rubocop-gradual.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir.glob("lib/**/*") + %w[exe/rubocop-gradual README.md LICENSE.txt CHANGELOG.md]
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "benchmark", ">=0.5.0"
   spec.add_dependency "diff-lcs", ">= 1.2.0", "< 2.0"
   spec.add_dependency "diffy", "~> 3.0"
   spec.add_dependency "parallel", "~> 1.10"


### PR DESCRIPTION
When running `rubocop-gradual`, I've noticed the following warning:
> rubocop-gradual-0.3.6/exe/rubocop-gradual:7: warning: benchmark was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0. You can add benchmark to your Gemfile or gemspec to silence this warning.

Adding the current `benchmark` gem to the gemspec file to resolve this.