### PR TITLE
Define --list as a native CLI option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+### Fixed
+
+- Define `--list` (`--list-target-files`) as a native rubocop-gradual option. Previously it relied on OptionParser expanding the abbreviation to RuboCop's `--list-target-files`, which broke with RuboCop >= 1.87 where `--list` became ambiguous. ([@skryukov])
+
 ## [0.3.6] - 2024-07-21
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Proposed workflow:
     -a, --autocorrect                Autocorrect offenses (only when it's safe).
     -A, --autocorrect-all            Autocorrect offenses (safe and unsafe).
         --gradual-file FILE          Specify Gradual lock file.
+        --list, --list-target-files  List target files.
     -v, --version                    Display version.
     -h, --help                       Prints this help.
 ```

--- a/lib/rubocop/gradual/options.rb
+++ b/lib/rubocop/gradual/options.rb
@@ -78,6 +78,8 @@ module RuboCop
         opts.on("--commit COMMIT", "Lint files changed since the commit.") do |commit|
           @lint_paths = git_lint_paths(commit)
         end
+
+        opts.on("--list", "--list-target-files", "List target files.") { @rubocop_options[:list_target_files] = true }
       end
 
       def define_info_options(opts)

--- a/spec/rubocop/gradual_spec.rb
+++ b/spec/rubocop/gradual_spec.rb
@@ -212,7 +212,7 @@ RSpec.describe RuboCop::Gradual, :aggregate_failures do
   end
 
   context "with --list option" do
-    let(:options) { %w[--list-target-files --gradual-file] }
+    let(:options) { %w[--list --gradual-file] }
 
     it "lists project files" do
       expect(gradual_cli).to eq(1)
@@ -220,7 +220,7 @@ RSpec.describe RuboCop::Gradual, :aggregate_failures do
     end
 
     context "with --autocorrect option" do
-      let(:options) { %w[--list-target-files --autocorrect --gradual-file] }
+      let(:options) { %w[--list --autocorrect --gradual-file] }
 
       it "lists project files" do
         expect(gradual_cli).to eq(1)
@@ -229,7 +229,7 @@ RSpec.describe RuboCop::Gradual, :aggregate_failures do
     end
 
     context "with --autocorrect option without changes" do
-      let(:options) { %w[--list-target-files --autocorrect --gradual-file] }
+      let(:options) { %w[--list --autocorrect --gradual-file] }
       let(:actual_lock_path) { File.expand_path("full.lock") }
 
       it "lists project files" do
@@ -239,12 +239,23 @@ RSpec.describe RuboCop::Gradual, :aggregate_failures do
     end
 
     context "with --autocorrect option and outdated lock file" do
-      let(:options) { %w[--list-target-files --autocorrect --gradual-file] }
+      let(:options) { %w[--list --autocorrect --gradual-file] }
       let(:actual_lock_path) { File.expand_path("outdated.lock") }
 
       it "lists project files" do
         expect(gradual_cli).to eq(1)
         expect($stdout.string).to eq("app/controllers/books_controller.rb\n")
+      end
+    end
+
+    %w[-L --list-target-files].each do |alias_flag|
+      context "with #{alias_flag} alias" do
+        let(:options) { [alias_flag, "--gradual-file"] }
+
+        it "lists project files" do
+          expect(gradual_cli).to eq(1)
+          expect($stdout.string.split("\n")).to match_array(Dir.glob("**/*.rb"))
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes the `--list` crash from #21: RuboCop 1.87 added `--list-enabled-cops-for`, which made `--list` an ambiguous abbreviation in RuboCop's option parser, so forwarding it raised `OptionParser::AmbiguousOption`:

```
$ rubocop-gradual --list
ambiguous option: --list (OptionParser::AmbiguousOption)
```

Now `--list`/`--list-target-files` are defined natively on the gradual parser (`-L` keeps working via RuboCop option passthrough, covered by specs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)