### PR TITLE
Add --standard option to lint with the Standard ruleset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning].
 
 ### Added
 
+- Add `--standard` option to lint with the [Standard](https://github.com/standardrb/standard) ruleset, including `.standard.yml` and `.standard_todo.yml` support. ([@skryukov])
 - Support RuboCop's `--parallel` option. Previously the flag was silently dropped before reaching the RuboCop runner. ([@skryukov])
 
 ### Fixed

--- a/Gemfile
+++ b/Gemfile
@@ -12,3 +12,7 @@ gem "rspec", "~> 3.0"
 gem "rubocop-performance"
 gem "rubocop-rake"
 gem "rubocop-rspec"
+
+# Standard pins exact RuboCop versions, so only install it on Rubies
+# where its RuboCop requirement matches the version under test.
+gem "standard", ">= 1.50" if RUBY_VERSION >= "3.0"

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Proposed workflow:
     -a, --autocorrect                Autocorrect offenses (only when it's safe).
     -A, --autocorrect-all            Autocorrect offenses (safe and unsafe).
         --gradual-file FILE          Specify Gradual lock file.
+        --standard                   Lint with the Standard ruleset.
         --list, --list-target-files  List target files.
     -v, --version                    Display version.
     -h, --help                       Prints this help.
@@ -103,6 +104,17 @@ rubocop-gradual --commit origin/main # run `rubocop-gradual` on changed files si
 # it's possible to combine options with autocorrect:
 rubocop-gradual --staged --autocorrect # run `rubocop-gradual` with autocorrect on staged files
 ```
+
+## Standard support (experimental)
+
+RuboCop Gradual can lint with the [Standard] ruleset instead of a RuboCop configuration. Add the [standard gem] to your Gemfile and pass the `--standard` option:
+
+```shell
+rubocop-gradual --standard # run `rubocop-gradual` with the Standard ruleset
+rubocop-gradual --standard -a # run `rubocop-gradual` with the Standard ruleset and autocorrect
+```
+
+RuboCop Gradual picks up `.standard.yml` and `.standard_todo.yml` configuration files, so existing Standard setups work as is.
 
 ## Require mode (experimental)
 
@@ -159,6 +171,8 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/skryuk
 The gem is available as open source under the terms of the [MIT License].
 
 [lefthook]: https://github.com/evilmartians/lefthook
+[Standard]: https://github.com/standardrb/standard
+[standard gem]: https://rubygems.org/gems/standard
 [RuboCop TODO file]: https://docs.rubocop.org/rubocop/configuration.html#automatically-generated-configuration
 [Pronto]: https://github.com/prontolabs/pronto-rubocop
 [Betterer]: https://github.com/phenomnomnominal/betterer

--- a/lib/rubocop/gradual/configuration.rb
+++ b/lib/rubocop/gradual/configuration.rb
@@ -12,6 +12,7 @@ module RuboCop
           @rubocop_options = rubocop_options
           @lint_paths = lint_paths
           @target_file_paths = nil
+          @standard_config_store = nil
           @rubocop_results = []
         end
 
@@ -40,12 +41,27 @@ module RuboCop
         end
 
         def rubocop_config_store
+          return standard_config_store if options[:standard]
+
           RuboCop::ConfigStore.new.tap do |config_store|
             config_store.options_config = rubocop_options[:config] if rubocop_options[:config]
           end
         end
 
         private
+
+        def standard_config_store
+          @standard_config_store ||= begin
+            require_standard
+            Standard::BuildsConfig.new.call([]).rubocop_config_store
+          end
+        end
+
+        def require_standard
+          require "standard"
+        rescue LoadError
+          raise Error, "Standard is not found, please add `gem \"standard\"` to your Gemfile first."
+        end
 
         def rubocop_target_file_paths
           target_finder = RuboCop::TargetFinder.new(rubocop_config_store, rubocop_options)

--- a/lib/rubocop/gradual/options.rb
+++ b/lib/rubocop/gradual/options.rb
@@ -56,8 +56,7 @@ module RuboCop
 
       def define_gradual_options(opts)
         opts.on("-a", "--autocorrect", "Autocorrect offenses (only when it's safe).") do
-          @rubocop_options[AUTOCORRECT_KEY] = true
-          @rubocop_options[:"safe_#{AUTOCORRECT_KEY}"] = true
+          @rubocop_options[AUTOCORRECT_KEY] = @rubocop_options[:"safe_#{AUTOCORRECT_KEY}"] = true
           @options[:command] = :autocorrect
         end
         opts.on("-A", "--autocorrect-all", "Autocorrect offenses (safe and unsafe).") do
@@ -66,6 +65,8 @@ module RuboCop
         end
 
         opts.on("--gradual-file FILE", "Specify Gradual lock file.") { |path| @options[:path] = path }
+
+        opts.on("--standard", "Lint with the Standard ruleset.") { @options[:standard] = true }
       end
 
       def define_lint_paths_options(opts)

--- a/spec/fixtures/standard_project/.standard.yml
+++ b/spec/fixtures/standard_project/.standard.yml
@@ -1,0 +1,1 @@
+ruby_version: 3.0

--- a/spec/fixtures/standard_project/lib/example.rb
+++ b/spec/fixtures/standard_project/lib/example.rb
@@ -1,0 +1,5 @@
+class Example
+  def call
+    puts 'single'
+  end
+end

--- a/spec/rubocop/gradual_standard_spec.rb
+++ b/spec/rubocop/gradual_standard_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Gradual, :aggregate_failures do
+  subject(:gradual_cli) { RuboCop::Gradual::CLI.new.run([*options, lock_path]) }
+
+  around do |example|
+    Dir.mktmpdir do |tmpdir|
+      tmpdir = File.realpath(tmpdir)
+      FileUtils.cp_r(File.join("spec/fixtures/standard_project"), tmpdir)
+
+      Dir.chdir(File.join(tmpdir, "standard_project")) do
+        RuboCop::PathUtil.reset_pwd if RuboCop::PathUtil.respond_to?(:reset_pwd)
+        example.run
+      end
+    end
+  end
+
+  before do
+    require "standard"
+    $stdout = StringIO.new
+    $stderr = StringIO.new
+  rescue LoadError
+    skip "the standard gem is not installed"
+  end
+
+  after do
+    $stdout = STDOUT
+    $stderr = STDERR
+  end
+
+  let(:options) { %w[--standard --gradual-file] }
+  let(:lock_path) { File.expand_path("result.lock") }
+
+  it "lints with the Standard ruleset" do
+    expect(gradual_cli).to eq(0)
+    expect(File.read(lock_path)).to include("Style/StringLiterals")
+    expect($stdout.string).to include("RuboCop Gradual got results for the first time. 1 issue(s) found.")
+  end
+
+  context "with --autocorrect option" do
+    let(:options) { %w[--standard --autocorrect --gradual-file] }
+
+    it "fixes offenses and removes the lock file" do
+      expect(gradual_cli).to eq(0)
+      expect(File.read("lib/example.rb")).to include('puts "single"')
+      expect(File.exist?(lock_path)).to be(false)
+    end
+  end
+end


### PR DESCRIPTION
Closes #4.

`rubocop-gradual --standard` lints with [Standard](https://github.com/standardrb/standard)'s ruleset instead of a RuboCop config. The integration point is small: Standard's `BuildsConfig` returns a fully configured `RuboCop::ConfigStore` (base ruleset + `.standard.yml` + `.standard_todo.yml` + plugins + target Ruby version), which slots directly into `Configuration.rubocop_config_store` — the target finder, lint run, and autocorrect all flow through it unchanged.

- Output verified byte-identical to `standardrb` on the same project.
- `--standard -a` autocorrects like `standardrb --fix`.
- The standard gem is required on demand; without it the CLI raises a friendly install hint, and specs skip.
- Gemfile installs standard only on Ruby >= 3.0 since Standard pins exact RuboCop versions that conflict with the versions under test on older Rubies.

Spiked from the issues review; happy to adjust scope (for example auto-detecting `.standard.yml` instead of requiring a flag) before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)